### PR TITLE
fix(frontend): show private profiles to friends on public profile page

### DIFF
--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -898,19 +898,45 @@ export class UserService {
       }
     }
 
-    const events = await this.prisma.event.findMany({
-      where: {
-        authorId: userId,
-        isPublished: true,
-        isPublic: true,
-        ...cursorFilter,
-      },
-      include: {
-        location: true,
-      },
-      orderBy: [{ startAt: 'desc' }, { id: 'desc' }],
-      take: limit + 1,
-    });
+    const pageWhere: Prisma.EventWhereInput = {
+      authorId: userId,
+      isPublished: true,
+      isPublic: true,
+      ...cursorFilter,
+    };
+    const countWhere: Prisma.EventWhereInput = {
+      authorId: userId,
+      isPublished: true,
+      isPublic: true,
+    };
+
+    let events;
+    let hostedPublicTotal: number | undefined;
+
+    if (!cursor) {
+      const [page, total] = await Promise.all([
+        this.prisma.event.findMany({
+          where: pageWhere,
+          include: {
+            location: true,
+          },
+          orderBy: [{ startAt: 'desc' }, { id: 'desc' }],
+          take: limit + 1,
+        }),
+        this.prisma.event.count({ where: countWhere }),
+      ]);
+      events = page;
+      hostedPublicTotal = total;
+    } else {
+      events = await this.prisma.event.findMany({
+        where: pageWhere,
+        include: {
+          location: true,
+        },
+        orderBy: [{ startAt: 'desc' }, { id: 'desc' }],
+        take: limit + 1,
+      });
+    }
 
     const hasMore = events.length > limit;
     const sliced = hasMore ? events.slice(0, limit) : events;
@@ -918,6 +944,15 @@ export class UserService {
     const nextCursor = hasMore
       ? Buffer.from(`${last.startAt.toISOString()}|${String(last.id)}`).toString('base64')
       : null;
+
+    const pagination: {
+      nextCursor: string | null;
+      hasMore: boolean;
+      total?: number;
+    } = { nextCursor, hasMore };
+    if (hostedPublicTotal !== undefined) {
+      pagination.total = hostedPublicTotal;
+    }
 
     return {
       data: sliced.map((event) => ({
@@ -928,7 +963,7 @@ export class UserService {
         imageKey: event.imageKey,
         location: event.location,
       })),
-      pagination: { nextCursor, hasMore },
+      pagination,
     };
   }
 }

--- a/apps/frontend/src/hooks/useInfiniteScroll.ts
+++ b/apps/frontend/src/hooks/useInfiniteScroll.ts
@@ -7,6 +7,8 @@ interface PaginatedItem {
 export interface Pagination {
   nextCursor: string | null;
   hasMore: boolean;
+  /** Set on first page when API returns total (e.g. hosted events count). */
+  total?: number;
 }
 
 /**

--- a/apps/frontend/src/pages/public-profile/Page.tsx
+++ b/apps/frontend/src/pages/public-profile/Page.tsx
@@ -42,19 +42,12 @@ export const publicProfileLoader = async ({ params }: LoaderFunctionArgs) => {
 
   const user = await userService.getUserByName(username);
 
-  // Only fetch events if profile is public (or the field is not set, for backwards compatibility)
-  let eventPage: ResUserPublicEventsPaginated = {
-    data: [],
-    pagination: { hasMore: false, nextCursor: null },
-  };
-  if (user.isProfilePublic !== false) {
-    eventPage = await userService.getUserEventsByName({ username });
-  }
+  const token = useAuthStore.getState().token;
+  const currentUserId = useCurrentUserStore.getState().user?.id;
 
   // Only fetch friendship status if user is logged in
   let friendshipStatus: FriendshipStatus = 'none';
   let friendRequestId: string | null = null;
-  const token = useAuthStore.getState().token;
   if (token) {
     try {
       const status = await userService.getFriendshipStatus(user.id);
@@ -83,6 +76,20 @@ export const publicProfileLoader = async ({ params }: LoaderFunctionArgs) => {
     }
   }
 
+  const canSeeHostedEvents =
+    user.isProfilePublic !== false ||
+    (currentUserId !== undefined && currentUserId === user.id) ||
+    friendshipStatus === 'friends' ||
+    friendshipStatus === 'self';
+
+  let eventPage: ResUserPublicEventsPaginated = {
+    data: [],
+    pagination: { hasMore: false, nextCursor: null },
+  };
+  if (canSeeHostedEvents) {
+    eventPage = await userService.getUserEventsByName({ username });
+  }
+
   return { user, eventPage, friendshipStatus, friendRequestId };
 };
 
@@ -95,7 +102,10 @@ export default function PublicProfilePage() {
 
   const isViewingSelf = currentUser?.id === data.user.id;
   const isLoggedIn = !!currentUser;
-  const isPrivateProfile = data.user.isProfilePublic === false;
+  const canViewPrivateProfileAsViewer =
+    isViewingSelf || friendshipStatus === 'friends' || friendshipStatus === 'self';
+  const showPrivateProfileGate =
+    data.user.isProfilePublic === false && !canViewPrivateProfileAsViewer;
 
   const handleFriendAction = async () => {
     if (!isLoggedIn) return;
@@ -164,7 +174,7 @@ export default function PublicProfilePage() {
     }
   };
 
-  if (isPrivateProfile && !isViewingSelf) {
+  if (showPrivateProfileGate) {
     return (
       <PrivateProfileView
         user={data.user}

--- a/apps/frontend/src/pages/public-profile/Page.tsx
+++ b/apps/frontend/src/pages/public-profile/Page.tsx
@@ -206,24 +206,24 @@ export default function PublicProfilePage() {
           className="flex gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm"
           role="status"
         >
-        {data.user.isProfilePublic !== false ? (
-          <Globe className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
-        ) : (
-          <Lock className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
-        )}
-        
-        <div className="space-y-1.5 min-w-0">
-          <p className="font-semibold text-foreground">
-            Your profile is {data.user.isProfilePublic !== false ? 'public' : 'private'}
-          </p>
-          <p className="text-muted-foreground leading-relaxed">
-            {data.user.isProfilePublic !== false 
-              ? 'Anyone can see your bio, location, and hosted public events.' 
-              : 'Only friends can see your bio, location, and hosted public events.'}
-          </p>
-          <Link
-            to="/profile#settings"
-            className="font-medium text-primary underline-offset-4 hover:underline inline-block"
+          {data.user.isProfilePublic !== false ? (
+            <Globe className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
+          ) : (
+            <Lock className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
+          )}
+
+          <div className="space-y-1.5 min-w-0">
+            <p className="font-semibold text-foreground">
+              Your profile is {data.user.isProfilePublic !== false ? 'public' : 'private'}
+            </p>
+            <p className="text-muted-foreground leading-relaxed">
+              {data.user.isProfilePublic !== false
+                ? 'Anyone can see your bio, location, and hosted public events.'
+                : 'Only friends can see your bio, location, and hosted public events.'}
+            </p>
+            <Link
+              to="/profile#settings"
+              className="font-medium text-primary underline-offset-4 hover:underline inline-block"
             >
               Change in profile settings
             </Link>

--- a/apps/frontend/src/pages/public-profile/Page.tsx
+++ b/apps/frontend/src/pages/public-profile/Page.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useCurrentUserStore } from '@/store/currentUserStore';
 import type { FriendshipStatus } from '@/types/friends';
 import type { ResUserPublicEventsPaginated } from '@grit/schema';
-import { Lock } from 'lucide-react';
+import { Lock, Globe } from 'lucide-react';
 import { useState } from 'react';
 import { Link, LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -201,20 +201,29 @@ export default function PublicProfilePage() {
   return (
     <div className="space-y-8">
       <BackButton />
-      {isViewingSelf && data.user.isProfilePublic === false && (
+      {isViewingSelf && (
         <div
           className="flex gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm"
           role="status"
         >
-          <Lock className="size-4 shrink-0 text-muted-foreground mt-0.5" aria-hidden />
-          <div className="space-y-1.5 min-w-0">
-            <p className="font-semibold text-foreground">Your profile is private</p>
-            <p className="text-muted-foreground leading-relaxed">
-              Only friends can see your bio, location and hosted public events.
-            </p>
-            <Link
-              to="/profile#settings"
-              className="font-medium text-primary underline-offset-4 hover:underline inline-block"
+        {data.user.isProfilePublic !== false ? (
+          <Globe className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
+        ) : (
+          <Lock className="size-4 shrink-0 text-muted-foreground mt-1.5" aria-hidden />
+        )}
+        
+        <div className="space-y-1.5 min-w-0">
+          <p className="font-semibold text-foreground">
+            Your profile is {data.user.isProfilePublic !== false ? 'public' : 'private'}
+          </p>
+          <p className="text-muted-foreground leading-relaxed">
+            {data.user.isProfilePublic !== false 
+              ? 'Anyone can see your bio, location, and hosted public events.' 
+              : 'Only friends can see your bio, location, and hosted public events.'}
+          </p>
+          <Link
+            to="/profile#settings"
+            className="font-medium text-primary underline-offset-4 hover:underline inline-block"
             >
               Change in profile settings
             </Link>

--- a/apps/frontend/src/pages/public-profile/Page.tsx
+++ b/apps/frontend/src/pages/public-profile/Page.tsx
@@ -5,8 +5,9 @@ import { useAuthStore } from '@/store/authStore';
 import { useCurrentUserStore } from '@/store/currentUserStore';
 import type { FriendshipStatus } from '@/types/friends';
 import type { ResUserPublicEventsPaginated } from '@grit/schema';
+import { Lock } from 'lucide-react';
 import { useState } from 'react';
-import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
+import { Link, LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import { toast } from 'sonner';
 import { PrivateProfileView } from './components/PrivateProfileView';
 import { ProfileHeader } from './components/ProfileHeader';
@@ -200,6 +201,26 @@ export default function PublicProfilePage() {
   return (
     <div className="space-y-8">
       <BackButton />
+      {isViewingSelf && data.user.isProfilePublic === false && (
+        <div
+          className="flex gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm"
+          role="status"
+        >
+          <Lock className="size-4 shrink-0 text-muted-foreground mt-0.5" aria-hidden />
+          <div className="space-y-1.5 min-w-0">
+            <p className="font-semibold text-foreground">Your profile is private</p>
+            <p className="text-muted-foreground leading-relaxed">
+              Only friends can see your bio, location and hosted public events.
+            </p>
+            <Link
+              to="/profile#settings"
+              className="font-medium text-primary underline-offset-4 hover:underline inline-block"
+            >
+              Change in profile settings
+            </Link>
+          </div>
+        </div>
+      )}
       <ProfileHeader
         user={data.user}
         friendshipStatus={friendshipStatus}

--- a/apps/frontend/src/pages/public-profile/components/ProfileTabs.tsx
+++ b/apps/frontend/src/pages/public-profile/components/ProfileTabs.tsx
@@ -39,6 +39,8 @@ export function ProfileTabs({
     }
   );
 
+  const eventsTabCount = initialPagination.total ?? events.length;
+
   return (
     <Tabs defaultValue="info" className="w-full" onValueChange={setActiveTab}>
       <TabsList variant="brutalist" className="w-full md:w-auto">
@@ -46,7 +48,7 @@ export function ProfileTabs({
           Info
         </TabsTrigger>
         <TabsTrigger value="events" variant="brutalist" className="text-xs md:text-sm">
-          Events {initialPagination.hasMore ? '' : `(${events.length})`}
+          Events ({eventsTabCount})
         </TabsTrigger>
       </TabsList>
 

--- a/apps/frontend/src/store/authStore.ts
+++ b/apps/frontend/src/store/authStore.ts
@@ -20,6 +20,25 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth',
+
+      // FIX: Prevent "The Vanishing Token" Race Condition (for e2e tests)
+      // Standard merge prefers localStorage over memory. If a user logs in
+      // extremely fast, the async hydration from disk can finish AFTER the
+      // login, overwriting the new token with 'null' from the old session.
+      // We only use the stored token if our current memory is empty.
+
+      partialize: (state) => ({ token: state.token }),
+      merge: (persistedState, currentState) => {
+        const p = (persistedState ?? {}) as { token?: string | null };
+        return {
+          ...currentState,
+          ...p,
+          token:
+            currentState.token != null && currentState.token !== ''
+              ? currentState.token
+              : (p.token ?? null),
+        };
+      },
     }
   )
 );

--- a/apps/frontend/src/store/authStore.ts
+++ b/apps/frontend/src/store/authStore.ts
@@ -33,10 +33,7 @@ export const useAuthStore = create<AuthState>()(
         return {
           ...currentState,
           ...p,
-          token:
-            currentState.token != null && currentState.token !== ''
-              ? currentState.token
-              : (p.token ?? null),
+          token: currentState.token ?? p.token ?? null,
         };
       },
     }

--- a/apps/frontend/src/store/currentUserStore.ts
+++ b/apps/frontend/src/store/currentUserStore.ts
@@ -27,6 +27,22 @@ export const useCurrentUserStore = create<CurrentUserState>()(
     }),
     {
       name: 'current-user',
+
+      // Prevent "The Vanishing User" Race Condition (seen in e2e tests)
+      // Standard merge prefers localStorage over memory. If a user logs in
+      // extremely fast, the async hydration from disk can finish AFTER the
+      // login, overwriting the fresh user data with 'null' from the old session.
+      // We only use the stored user if our current memory is empty.
+
+      partialize: (state) => ({ user: state.user }),
+      merge: (persistedState, currentState) => {
+        const p = (persistedState ?? {}) as { user?: CurrentUser | null };
+        return {
+          ...currentState,
+          ...p,
+          user: currentState.user ?? p.user ?? null,
+        };
+      },
     }
   )
 );

--- a/apps/frontend/tests/e2e/auth.spec.ts
+++ b/apps/frontend/tests/e2e/auth.spec.ts
@@ -77,6 +77,16 @@ test.describe('Authentication Flow', () => {
         },
       });
     });
+
+    // Events loader calls listFriends when a token exists; avoid real API with fake JWT
+    await page.route('**/api/users/me/friends*', async (route) => {
+      await route.fulfill({
+        json: {
+          data: [],
+          pagination: { nextCursor: null, hasMore: false, total: 0 },
+        },
+      });
+    });
   });
 
   test('should allow user to login', async ({ page }) => {
@@ -94,9 +104,8 @@ test.describe('Authentication Flow', () => {
     await expect(page.getByText('You are logged in')).toBeVisible();
     await expect(page).toHaveURL(/\/events/);
 
-    // Verify user is visible in Navbar
-    // The avatar fallback uses the first letter of the name (T for Test User)
-    await expect(page.getByRole('button', { name: 'Test User' })).toBeVisible();
+    // Logged-in chrome (depends on token only; desktop nav)
+    await expect(page.getByRole('link', { name: 'Chat' })).toBeVisible();
   });
 
   test('should allow user to register', async ({ page }) => {

--- a/apps/frontend/tests/e2e/auth.spec.ts
+++ b/apps/frontend/tests/e2e/auth.spec.ts
@@ -77,16 +77,6 @@ test.describe('Authentication Flow', () => {
         },
       });
     });
-
-    // Events loader calls listFriends when a token exists; avoid real API with fake JWT
-    await page.route('**/api/users/me/friends*', async (route) => {
-      await route.fulfill({
-        json: {
-          data: [],
-          pagination: { nextCursor: null, hasMore: false, total: 0 },
-        },
-      });
-    });
   });
 
   test('should allow user to login', async ({ page }) => {
@@ -104,8 +94,9 @@ test.describe('Authentication Flow', () => {
     await expect(page.getByText('You are logged in')).toBeVisible();
     await expect(page).toHaveURL(/\/events/);
 
-    // Logged-in chrome (depends on token only; desktop nav)
-    await expect(page.getByRole('link', { name: 'Chat' })).toBeVisible();
+    // Verify user is visible in Navbar
+    // The avatar fallback uses the first letter of the name (T for Test User)
+    await expect(page.getByRole('button', { name: 'Test User' })).toBeVisible();
   });
 
   test('should allow user to register', async ({ page }) => {

--- a/packages/schema/src/user.ts
+++ b/packages/schema/src/user.ts
@@ -102,7 +102,11 @@ export type ResUserPublicEvents = z.infer<typeof ResUserPublicEventsSchema>;
 
 export const ResUserPublicEventsPaginatedSchema = z.object({
   data: ResUserPublicEventsSchema,
-  pagination: z.object({ nextCursor: z.string().nullable(), hasMore: z.boolean() }),
+  pagination: z.object({
+    nextCursor: z.string().nullable(),
+    hasMore: z.boolean(),
+    total: z.number().int().nonnegative().optional(),
+  }),
 });
 export type ResUserPublicEventsPaginated = z.infer<typeof ResUserPublicEventsPaginatedSchema>;
 


### PR DESCRIPTION
- Events are now correctly fetched in public profile when profile is set to 'private'
- Public profile set to 'private' can now be accessed by friends
- **Test FE 2e2**: Fixed a weird bug where logging in was too fast for the app. My computer (fast one!) was finishing the login before the old saved data could load from the browser, which caused the old "empty" session to accidentally overwrite the new one and log the user right back out.
- Short note on the user's own public profile informing on the current privacy setting
<img width="862" height="555" alt="Screenshot 2026-03-22 at 11 47 02" src="https://github.com/user-attachments/assets/99139a43-13b5-4818-ba3f-50e97688484c" />

- Added event number in public profile, also when there is pagination (this was just kept empty before)

<img width="511" height="243" alt="Screenshot 2026-03-22 at 13 11 29" src="https://github.com/user-attachments/assets/f82b94b4-556a-435e-b777-9ae1a11a599c" />
